### PR TITLE
RFC: removing redundant and lengthy docstring of `binarize`

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,6 @@
 push!(LOAD_PATH,"../src/")
 using Documenter, ImageBinarization, ColorTypes, ColorVectorSpace
 makedocs(sitename="Documentation",
+         sitename = "ImageBinarization",
             Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"))
 deploydocs(repo = "github.com/zygmuntszpak/ImageBinarization.jl.git")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,5 @@
 push!(LOAD_PATH,"../src/")
 using Documenter, ImageBinarization, ColorTypes, ColorVectorSpace
 makedocs(sitename="Documentation",
-         sitename = "ImageBinarization",
-            Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"))
+         Documenter.HTML(prettyurls = get(ENV, "CI", nothing) == "true"))
 deploydocs(repo = "github.com/zygmuntszpak/ImageBinarization.jl.git")

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,69 +4,97 @@
 Depth = 3
 ```
 
-# Functions
+## Overview
 
-## Adaptive Threshold
+TODO: some description on how to use this package
+
 ```@docs
-binarize(::AdaptiveThreshold, ::AbstractArray{<: Colorant,2})
+BinarizationAlgorithm
 ```
 
-## Balanced
+The core function `binarize` can be used in a generic way:
+
+```@docs
+binarize
+```
+
+## Binarization Algorithms
+
+### Adaptive Threshold
+```@docs
+binarize(::AdaptiveThreshold,  ::AbstractArray{<: Colorant,2})
+AdaptiveThreshold
+recommend_size
+```
+
+### Balanced
 ```@docs
 binarize(::Balanced,  ::AbstractArray{<: Colorant,2})
+Balanced
 ```
 
-## Entropy
+### Entropy
 ```@docs
-binarize(::Entropy,  ::AbstractArray{T,2}) where T <: Colorant
+binarize(::Entropy,  ::AbstractArray{<: Colorant,2})
+Entropy
 ```
 
-## Intermodes
+### Intermodes
 ```@docs
 binarize(::Intermodes,  ::AbstractArray{<: Colorant,2})
+Intermodes
 ```
 
-## Minimum Error
+### Minimum Error
 ```@docs
 binarize(::MinimumError,  ::AbstractArray{<: Colorant,2})
+MinimumError
 ```
 
-## Minimum Intermodes
+### Minimum Intermodes
 ```@docs
 binarize(::MinimumIntermodes,  ::AbstractArray{<: Colorant,2})
+MinimumIntermodes
 ```
 
-## Moments
+### Moments
 ```@docs
 binarize(::Moments,  ::AbstractArray{<: Colorant,2})
+Moments
 ```
 
-## Niblack
+### Niblack
 ```@docs
 binarize(::Niblack,  ::AbstractArray{<: Colorant,2})
+Niblack
 ```
 
-## Otsu
+### Otsu
 ```@docs
 binarize(::Otsu,  ::AbstractArray{<: Colorant,2})
+Otsu
 ```
 
-## Polysegment
+### Polysegment
 ```@docs
 binarize(::Polysegment,  ::AbstractArray{<: Colorant,2})
+Polysegment
 ```
 
-## Sauvola
+### Sauvola
 ```@docs
 binarize(::Sauvola,  ::AbstractArray{<: Colorant,2})
+Sauvola
 ```
 
-## Unimodal Rosin
+### Unimodal Rosin
 ```@docs
 binarize(::UnimodalRosin,  ::AbstractArray{<: Colorant,2})
+UnimodalRosin
 ```
 
-## Yen
+### Yen
 ```@docs
 binarize(::Yen,  ::AbstractArray{<: Colorant,2})
+Yen
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,7 +4,7 @@
 Depth = 3
 ```
 
-## Overview
+# Overview
 
 TODO: some description on how to use this package
 
@@ -18,82 +18,82 @@ The core function `binarize` can be used in a generic way:
 binarize
 ```
 
-## Binarization Algorithms
+# Binarization Algorithms
 
-### Adaptive Threshold
+## Adaptive Threshold
 ```@docs
 binarize(::AdaptiveThreshold,  ::AbstractArray{<: Colorant,2})
 AdaptiveThreshold
 recommend_size
 ```
 
-### Balanced
+## Balanced
 ```@docs
 binarize(::Balanced,  ::AbstractArray{<: Colorant,2})
 Balanced
 ```
 
-### Entropy
+## Entropy
 ```@docs
 binarize(::Entropy,  ::AbstractArray{<: Colorant,2})
 Entropy
 ```
 
-### Intermodes
+## Intermodes
 ```@docs
 binarize(::Intermodes,  ::AbstractArray{<: Colorant,2})
 Intermodes
 ```
 
-### Minimum Error
+## Minimum Error
 ```@docs
 binarize(::MinimumError,  ::AbstractArray{<: Colorant,2})
 MinimumError
 ```
 
-### Minimum Intermodes
+## Minimum Intermodes
 ```@docs
 binarize(::MinimumIntermodes,  ::AbstractArray{<: Colorant,2})
 MinimumIntermodes
 ```
 
-### Moments
+## Moments
 ```@docs
 binarize(::Moments,  ::AbstractArray{<: Colorant,2})
 Moments
 ```
 
-### Niblack
+## Niblack
 ```@docs
 binarize(::Niblack,  ::AbstractArray{<: Colorant,2})
 Niblack
 ```
 
-### Otsu
+## Otsu
 ```@docs
 binarize(::Otsu,  ::AbstractArray{<: Colorant,2})
 Otsu
 ```
 
-### Polysegment
+## Polysegment
 ```@docs
 binarize(::Polysegment,  ::AbstractArray{<: Colorant,2})
 Polysegment
 ```
 
-### Sauvola
+## Sauvola
 ```@docs
 binarize(::Sauvola,  ::AbstractArray{<: Colorant,2})
 Sauvola
 ```
 
-### Unimodal Rosin
+## Unimodal Rosin
 ```@docs
 binarize(::UnimodalRosin,  ::AbstractArray{<: Colorant,2})
 UnimodalRosin
 ```
 
-### Yen
+## Yen
 ```@docs
 binarize(::Yen,  ::AbstractArray{<: Colorant,2})
 Yen

--- a/src/ImageBinarization.jl
+++ b/src/ImageBinarization.jl
@@ -10,31 +10,6 @@ using Statistics
 using ImageCore
 
 abstract type BinarizationAlgorithm end
-struct Otsu <: BinarizationAlgorithm end
-struct Polysegment <: BinarizationAlgorithm end
-struct UnimodalRosin <: BinarizationAlgorithm end
-struct MinimumIntermodes <: BinarizationAlgorithm end
-struct Moments <: BinarizationAlgorithm end
-struct Intermodes <: BinarizationAlgorithm end
-struct MinimumError <: BinarizationAlgorithm end
-struct Balanced <: BinarizationAlgorithm end
-struct Yen <: BinarizationAlgorithm end
-struct Entropy <: BinarizationAlgorithm end
-
-struct AdaptiveThreshold <: BinarizationAlgorithm
-    window_size::Int
-    percentage::Int
-end
-
-struct Sauvola <: BinarizationAlgorithm
-    window_size::Int
-    bias::Float32
-end
-
-struct Niblack <: BinarizationAlgorithm
-    window_size::Int
-    bias::Float32
-end
 
 include("integral_image.jl")
 include("util.jl")
@@ -52,11 +27,11 @@ include("entropy.jl")
 include("sauvola.jl")
 include("niblack.jl")
 
-
 export
     # main functions
     binarize,
-    recommend_size,
+    BinarizationAlgorithm,
+    recommend_size, # AdaptiveThreshold
     AdaptiveThreshold,
     Otsu,
     Balanced,
@@ -70,4 +45,49 @@ export
     Entropy,
     Sauvola,
     Niblack
+
+"""
+`BinarizationAlgorithm` is an abstract type, you can't instantiate it.
+
+A list of implemented alogrithms are:
+
+* [`AdaptiveThreshold(; percentage = 15, window_size = 32)`](@ref ImageBinarization.AdaptiveThreshold)
+* [`Balanced()`](@ref ImageBinarization.Balanced)
+* [`Entropy()`](@ref ImageBinarization.Entropy)
+* [`Intermodes()`](@ref ImageBinarization.Intermodes)
+* [`MinimumError()`](@ref ImageBinarization.MinimumError)
+* [`MinimumIntermodes()`](@ref ImageBinarization.MinimumIntermodes)
+* [`Moments()`](@ref ImageBinarization.Moments)
+* [`Niblack(; window_size = 7, bias = 0.2)`](@ref ImageBinarization.Niblack)
+* [`Otsu()`](@ref ImageBinarization.Otsu)
+* [`Polysegment()`](@ref ImageBinarization.Polysegment)
+* [`Sauvola(; window_size = 7, bias = 0.2)`](@ref ImageBinarization.Sauvola)
+* [`UnimodalRosin()`](@ref ImageBinarization.UnimodalRosin)
+* [`Yen()`](@ref ImageBinarization.Yen)
+"""
+BinarizationAlgorithm
+
+"""
+    binarize(algorithm::BinarizationAlgorithm,  img::AbstractArray{T,2}) where T <: Colorant
+
+Returns the binarized image as an `Array{Gray{Bool},2}`
+
+# Example
+Binarizes the "cameraman" image in the `TestImages` package using `Otsu` method. All other algorithms are used in a similar way.
+
+```julia
+using TestImages, ImageBinarization
+
+img = testimage("cameraman")
+binarize_method = Otsu()
+img_binary = binarize(binarize_method, img)
+```
+
+!!! warning
+    * color image input `img` is automatically converted to `Gray` if a graylevel histogram is needed.
+
+See also: [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+binarize
+
 end # module

--- a/src/balanced.jl
+++ b/src/balanced.jl
@@ -56,7 +56,7 @@ struct Balanced <: BinarizationAlgorithm end
 
 Binarizes the image using the balanced histogram thresholding method.
 
-Check [`Blanced`](@ref ImageBinarization.Balanced) for more details
+Check [`Balanced`](@ref ImageBinarization.Balanced) for more details
 """
 function binarize(algorithm::Balanced,  img::AbstractArray{T,2}) where T <: Colorant
   img₀₁ = zeros(Gray{Bool}, axes(img))

--- a/src/balanced.jl
+++ b/src/balanced.jl
@@ -1,12 +1,7 @@
 @doc raw"""
-```
-binarize(Balanced(), img)
-```
-Binarizes the image using the balanced histogram thresholding method.
+    Balanced()
 
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
+Construct an instance of `Balanced` image binarization algorithm
 
 # Details
 In balanced histogram thresholding, one interprets a  bin as a  physical weight
@@ -47,38 +42,28 @@ the original histogram must have a single peak and the algorithm has failed to
 find a suitable threshold. In this case the algorithm will fall back to using
 the `UnimodalRosin` method to select the threshold.
 
-
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(Balanced(), img)
-```
-
 # Reference
 
-1. “BI-LEVEL IMAGE THRESHOLDING - A Fast Method”, Proceedings of the First International Conference on Bio-inspired Systems and Signal Processing, 2008. Available: [10.5220/0001064300700076](https://doi.org/10.5220/0001064300700076)
+1. “BI-LEVEL IMAGE THRESHOLDING - A Fast Method”, *Proceedings of the First International Conference on Bio-inspired Systems and Signal Processing*, 2008. Available: [10.5220/0001064300700076](https://doi.org/10.5220/0001064300700076)
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct Balanced <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::Balanced,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using the balanced histogram thresholding method.
+
+Check [`Blanced`](@ref ImageBinarization.Balanced) for more details
 """
 function binarize(algorithm::Balanced,  img::AbstractArray{T,2}) where T <: Colorant
-    img₀₁ = zeros(Gray{Bool}, axes(img))
-    edges, counts = build_histogram(img,  256)
-    t = find_threshold(HistogramThresholding.Balanced(), counts[1:end], edges)
-    for i in CartesianIndices(img)
-      img₀₁[i] = img[i] < t ? 0 : 1
-    end
-    img₀₁
+  img₀₁ = zeros(Gray{Bool}, axes(img))
+  edges, counts = build_histogram(img,  256)
+  t = find_threshold(HistogramThresholding.Balanced(), counts[1:end], edges)
+  for i in CartesianIndices(img)
+    img₀₁[i] = img[i] < t ? 0 : 1
+  end
+  img₀₁
 end

--- a/src/entropy.jl
+++ b/src/entropy.jl
@@ -1,13 +1,10 @@
 """
-```
-binarize(Entropy(), img)
-```
+    Entropy()
+
+Constructs an instance of `Entropy` image binarization algorithm.
+
 An algorithm for finding the binarization threshold value using
 the entropy of the image histogram.
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
 
 # Details
 
@@ -54,28 +51,22 @@ the sought-after threshold value (i.e. the bin which determines the threshold).
 
 See Section 4 of [1] for more details on the derivation of the entropy.
 
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(Entropy(), img)
-```
-
 # References
+
 1. J. N. Kapur, P. K. Sahoo, and A. K. C. Wong, “A new method for gray-level picture thresholding using the entropy of the histogram,” *Computer Vision, Graphics, and Image Processing*, vol. 29, no. 1, p. 140, Jan. 1985.[doi:10.1016/s0734-189x(85)90156-2](https://doi.org/10.1016/s0734-189x%2885%2990156-2)
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct Entropy <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::Entropy,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using `Entropy` method by finding the binarization threshold value
+using the entropy of the image histogram.
+
+Check [`Entropy`](@ref ImageBinarization.Entropy) for more details.
 """
 function binarize(algorithm::Entropy,  img::AbstractArray{T,2}) where T <: Colorant
     img₀₁ = zeros(Gray{Bool}, axes(img))

--- a/src/intermodes.jl
+++ b/src/intermodes.jl
@@ -1,46 +1,36 @@
 """
-```
-binarize(Intermodes(), img)
-```
+    Intermodes()
+
+Constructs an instance of `Intermodes` image binarization algorithm.
 
 Under the assumption that the image histogram is bimodal the image histogram is
 smoothed using a length-3 mean filter until two modes remain. The binarization
 threshold is then set to the average value of the two modes.
 
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
-
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(Intermodes(), img)
-```
-
 ## Reference
 
-1. C. A. Glasbey, “An Analysis of Histogram-Based Thresholding Algorithms,” CVGIP: Graphical Models and Image Processing, vol. 55, no. 6, pp. 532–537, Nov. 1993. [doi:10.1006/cgip.1993.1040](https://doi.org/10.1006/cgip.1993.1040)
+1. C. A. Glasbey, “An Analysis of Histogram-Based Thresholding Algorithms,” *CVGIP: Graphical Models and Image Processing*, vol. 55, no. 6, pp. 532–537, Nov. 1993. [doi:10.1006/cgip.1993.1040](https://doi.org/10.1006/cgip.1993.1040)
+"""
+struct Intermodes <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::Intermodes,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using `Intermodes` histogram thresholding method.
+
+Under the assumption that the image histogram is bimodal the image histogram is
+smoothed using a length-3 mean filter until two modes remain. The binarization
+threshold is then set to the average value of the two modes.
+
+Check [`Intermodes`](@ref ImageBinarization.Intermodes) for more details.
 """
 function binarize(algorithm::Intermodes,  img::AbstractArray{T,2}) where T <: Colorant
-    img₀₁ = zeros(Gray{Bool}, axes(img))
-    edges, counts = build_histogram(img,  256)
-    t = find_threshold(HistogramThresholding.Intermodes(), counts[1:end], edges)
-    for i in CartesianIndices(img)
-      img₀₁[i] = img[i] < t ? 0 : 1
-    end
-    img₀₁
+  img₀₁ = zeros(Gray{Bool}, axes(img))
+  edges, counts = build_histogram(img,  256)
+  t = find_threshold(HistogramThresholding.Intermodes(), counts[1:end], edges)
+  for i in CartesianIndices(img)
+    img₀₁[i] = img[i] < t ? 0 : 1
+  end
+  img₀₁
 end

--- a/src/minimum.jl
+++ b/src/minimum.jl
@@ -1,47 +1,34 @@
 """
-```
-binarize(MinimumIntermodes(), img)
-```
+    MinimumIntermodes()
 
-Under the assumption that the image histogram is bimodal the histogram is
-smoothed using a length-3 mean filter until two modes remain. The binarization
-threshold is then set to the minimum value between the two modes.
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
-
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(MinimumIntermodes(), img)
-```
+Constructs an instance of  `MinimumIntermodes` image binarization algorithm.
 
 # Reference
 
 1. C. A. Glasbey, “An Analysis of Histogram-Based Thresholding Algorithms,” *CVGIP: Graphical Models and Image Processing*, vol. 55, no. 6, pp. 532–537, Nov. 1993. [doi:10.1006/cgip.1993.1040](https://doi.org/10.1006/cgip.1993.1040)
 2. J. M. S. Prewitt and M. L. Mendelsohn, “THE ANALYSIS OF CELL IMAGES*,” *Annals of the New York Academy of Sciences*, vol. 128, no. 3, pp. 1035–1053, Dec. 2006. [doi:10.1111/j.1749-6632.1965.tb11715.x](https://doi.org/10.1111/j.1749-6632.1965.tb11715.x)
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct MinimumIntermodes <: BinarizationAlgorithm end
+
+"""
+    binarize(algorithm::MinimumIntermodes,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using `MinimumIntermodes` histogram thresholding method.
+
+Under the assumption that the image histogram is bimodal the histogram is
+smoothed using a length-3 mean filter until two modes remain. The binarization
+threshold is then set to the minimum value between the two modes.
+
+Check [`MinimumIntermodes`](@ref ImageBinarization.MinimumIntermodes) for more details
 """
 function binarize(algorithm::MinimumIntermodes,  img::AbstractArray{T,2}) where T <: Colorant
-    img₀₁ = zeros(Gray{Bool}, axes(img))
-    edges, counts = build_histogram(img,  256)
-    t = find_threshold(HistogramThresholding.MinimumIntermodes(), counts[1:end], edges)
-    for i in CartesianIndices(img)
-      img₀₁[i] = img[i] < t ? 0 : 1
-    end
-    img₀₁
+  img₀₁ = zeros(Gray{Bool}, axes(img))
+  edges, counts = build_histogram(img,  256)
+  t = find_threshold(HistogramThresholding.MinimumIntermodes(), counts[1:end], edges)
+  for i in CartesianIndices(img)
+    img₀₁[i] = img[i] < t ? 0 : 1
+  end
+  img₀₁
 end

--- a/src/minimum_error.jl
+++ b/src/minimum_error.jl
@@ -1,15 +1,7 @@
 @doc raw"""
-```
-binarize(MinimumError(), img)
-```
+    MinimumError()
 
-Under the assumption that the image histogram is a mixture of two Gaussian
-distributions the binarization threshold is chosen such that the expected
-misclassification error rate is minimised.
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
+Constructs a instance of `MinimumError` image binarization algorithm.
 
 # Details
 
@@ -43,30 +35,26 @@ and the piecewise-constant probability density function represented by the histo
 The discrete value ``T`` which minimizes the function ``J(T)`` produces
 the sought-after threshold value (i.e. the bin which determines the threshold).
 
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(MinimumError(), img)
-```
 
 # References
 
 1. J. Kittler and J. Illingworth, “Minimum error thresholding,” Pattern Recognition, vol. 19, no. 1, pp. 41–47, Jan. 1986. [doi:10.1016/0031-3203(86)90030-0](https://doi.org/10.1016/0031-3203%2886%2990030-0)
 2. Q.-Z. Ye and P.-E. Danielsson, “On minimum error thresholding and its implementations,” Pattern Recognition Letters, vol. 7, no. 4, pp. 201–206, Apr. 1988. [doi:10.1016/0167-8655(88)90103-1](https://doi.org/10.1016/0167-8655%2888%2990103-1)
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct MinimumError <: BinarizationAlgorithm end
+
+"""
+    binarize(algorithm::MinimumError,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using `MinimumError` histogram thresholding method.
+
+Under the assumption that the image histogram is a mixture of two Gaussian
+distributions the binarization threshold is chosen such that the expected
+misclassification error rate is minimised.
+
+Check [`MinimumError`](@ref ImageBinarization.MinimumError) for more details
 """
 function binarize(algorithm::MinimumError,  img::AbstractArray{T,2}) where T <: Colorant
   img₀₁ = zeros(Gray{Bool}, axes(img))

--- a/src/moments.jl
+++ b/src/moments.jl
@@ -1,16 +1,12 @@
 @doc raw"""
-```
-binarize(Moments(), img)
-```
+    Moments()
+
+Constructs an instance of `Moments` image binarization algorithm.
 
 The following rule determines the binarization threshold:  if one assigns all
 observations below the threshold to a value z₀ and all observations above the
 threshold to a value z₁, then the first three moments of the original histogram
 must match the moments of this specially constructed bilevel histogram.
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
 
 # Details
 
@@ -49,31 +45,26 @@ represents the moments of ``f``. To find the desired treshold value, one first s
 the four equations to obtain ``q_0`` and ``q_1``, and then chooses the threshold
 ``t`` such that ``q_0 = \sum_{z_i \le t} p_i``.
 
-
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(Moments(), img)
-```
-
 # Reference
 
-[1] W.-H. Tsai, “Moment-preserving thresolding: A new approach,” Computer Vision, Graphics, and Image Processing, vol. 29, no. 3, pp. 377–393, Mar. 1985. [doi:10.1016/0734-189x(85)90133-1](https://doi.org/10.1016/0734-189x%2885%2990133-1)
+1. W.-H. Tsai, “Moment-preserving thresolding: A new approach,” *Computer Vision, Graphics, and Image Processing*, vol. 29, no. 3, pp. 377–393, Mar. 1985. [doi:10.1016/0734-189x(85)90133-1](https://doi.org/10.1016/0734-189x%2885%2990133-1)
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct Moments <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::Moments,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using `Moments` histogram thresholding method.
+
+The following rule determines the binarization threshold:  if one assigns all
+observations below the threshold to a value z₀ and all observations above the
+threshold to a value z₁, then the first three moments of the original histogram
+must match the moments of this specially constructed bilevel histogram.
+
+Check [`Moments`](@ref ImageBinarization.Moments) for more details.
 """
 function binarize(algorithm::Moments,  img::AbstractArray{T,2}) where T <: Colorant
   img₀₁ = zeros(Gray{Bool}, axes(img))

--- a/src/niblack.jl
+++ b/src/niblack.jl
@@ -1,14 +1,7 @@
 """
-```
-binarize(Niblack(; window_size = 7, bias = 0.2), img)
-```
+    Niblack(; window_size = 7, bias = 0.2)
 
-Applies Niblack adaptive thresholding [1] under the assumption that the input
-image is textual.
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
+Constructs an instance of Niblack adaptive image binarization algorithm.
 
 # Details
 
@@ -32,11 +25,6 @@ implements an attempt to address this issue [2].
 
 # Arguments
 
-## `img`
-
-An image which is binarized according to a per-pixel adaptive
-threshold into background (0) and foreground (1) pixel values.
-
 ## `window_size` (denoted by ``w`` in the publication)
 
 The threshold for each pixel is a function of the distribution of the intensities
@@ -47,46 +35,51 @@ window is ``2w + 1``, with the target pixel in the center position.
 
 A user-defined biasing parameter. This can take negative values.
 
-# Example
+# References
 
-Binarize the "cameraman" image in the `TestImages` package.
+1. J. Sauvola and M. Pietikäinen (2000). "Adaptive document image binarization". *Pattern Recognition* 33 (2): 225-236. [doi:10.1016/S0031-3203(99)00055-2](https://doi.org/10.1016/S0031-3203(99)00055-2)
+"""
+struct Niblack <: BinarizationAlgorithm
+  window_size::Int
+  bias::Float32
+end
+Niblack(; window_size::Int = 7, bias::Real = 0.2) = Niblack(window_size, bias)
 
-```julia
-using TestImages, ImageBinarization
 
-img = testimage("cameraman")
-img_binary = binarize(Niblack(window_size = 9, bias = 0.2), img)
-```
+"""
+    binarize(algorithm::Niblack, img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image into background (0) and foreground (1) using Niblack adaptive image
+binarization method [1] under the assumption that the input image is textual.
+
+Check [`Niblack`](@ref ImageBinarization.Niblack) for more details
 
 # References
 
 1. Wayne Niblack (1986). *An Introduction to Image Processing*. Prentice-Hall, Englewood Cliffs, NJ: 115-16.
-2. J. Sauvola and M. Pietikäinen (2000). "Adaptive document image binarization". *Pattern Recognition* 33 (2): 225-236. [doi:10.1016/S0031-3203(99)00055-2](https://doi.org/10.1016/S0031-3203(99)00055-2)
 """
 function binarize(algorithm::Niblack, img::AbstractArray{T,2}) where T <: Colorant
-    binarize(algorithm, Gray.(img))
+  binarize(algorithm, Gray.(img))
 end
 
 function binarize(algorithm::Niblack, img::AbstractArray{T,2}) where T <: AbstractGray
-    w = algorithm.window_size
-    k = algorithm.bias
-    img₀₁ = zeros(Gray{Bool}, axes(img))
-    img_raw = channelview(img)
-    I = integral_image(img_raw)
-    I² = integral_image(img_raw.^2)
+  w = algorithm.window_size
+  k = algorithm.bias
+  img₀₁ = zeros(Gray{Bool}, axes(img))
+  img_raw = channelview(img)
+  I = integral_image(img_raw)
+  I² = integral_image(img_raw.^2)
 
-    function threshold(pixel::CartesianIndex{2})
-        row₀, col₀, row₁, col₁ = get_window_bounds(img, pixel, w)
-        m = μ_in_window(I, row₀, col₀, row₁, col₁)
-        s = σ_in_window(I², m, row₀, col₀, row₁, col₁)
-        return m + (k * s)
-    end
+  function threshold(pixel::CartesianIndex{2})
+    row₀, col₀, row₁, col₁ = get_window_bounds(img, pixel, w)
+    m = μ_in_window(I, row₀, col₀, row₁, col₁)
+    s = σ_in_window(I², m, row₀, col₀, row₁, col₁)
+    return m + (k * s)
+  end
 
-    for pixel in CartesianIndices(img)
-        img₀₁[pixel] = img[pixel] <= threshold(pixel) ? 0 : 1
-    end
+  for pixel in CartesianIndices(img)
+    img₀₁[pixel] = img[pixel] <= threshold(pixel) ? 0 : 1
+  end
 
-    return img₀₁
+  return img₀₁
 end
-
-Niblack(; window_size::Int = 7, bias::Real = 0.2) = Niblack(window_size, bias)

--- a/src/otsu.jl
+++ b/src/otsu.jl
@@ -1,14 +1,7 @@
 @doc raw"""
-```
-binarize(Otsu(), img)
-```
+    Otsu()
 
-Under the assumption that the image histogram is bimodal the binarization
-threshold is set so that the resultant between-class variance is maximal.
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
+Constructs an instance of `Otsu` image binarization algorithm.
 
 # Details
 
@@ -52,30 +45,24 @@ decided by minimizing the within-category variances criterion ``\sigma_w^2(T)``.
 Furthermore, that threshold is also the same as the threshold calculated by
 maximizing the ratio of between-category variance to within-category variance.
 
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(Otsu(), img)
-```
-
 # Reference
 
 1. Nobuyuki Otsu (1979). “A threshold selection method from gray-level histograms”. *IEEE Trans. Sys., Man., Cyber.* 9 (1): 62–66. [doi:10.1109/TSMC.1979.4310076](http://dx.doi.org/doi:10.1109/TSMC.1979.4310076)
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct Otsu <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::Otsu,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using `Otsu` histogram thresholding method.
+
+Under the assumption that the image histogram is bimodal the binarization
+threshold is set so that the resultant between-class variance is maximal.
+
+Check [`Otsu`](@ref ImageBinarization.Otsu) for more details
 """
 function binarize(algorithm::Otsu,  img::AbstractArray{T,2}) where T <: Colorant
   img₀₁ = zeros(Gray{Bool}, axes(img))

--- a/src/polysegment.jl
+++ b/src/polysegment.jl
@@ -1,10 +1,7 @@
 """
-```
-binarize(Polysegment(), img)
-```
+    Polysegment()
 
-Uses the *polynomial segmentation* technique to group the image pixels
-into two categories (foreground and background).
+Constructs a `Polysegment` image binarization algorithm.
 
 # Details
 
@@ -14,30 +11,23 @@ of two cluster centers (i.e the foreground and background). Pixels are then
 assigned to the foreground or background depending on which cluster center
 is closest.
 
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray`.
-
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(Polysegment(), img)
-```
-
 ## Reference
 
 1. R. E. Vidal, "Generalized Principal Component Analysis (GPCA): An Algebraic Geometric Approach to Subspace Clustering and Motion Segmentation." Order No. 3121739, University of California, Berkeley, Ann Arbor, 2003.
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct Polysegment <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::Polysegment,  img::AbstractArray{T,2}) where T <: Colorant
+
+Uses the *polynomial segmentation* technique to group the image pixels
+into two categories (foreground and background).
+
+
+Check [`Polysegment`](@ref ImageBinarization.Polysegment) for more details
 """
 function binarize(algorithm::Polysegment,  img::AbstractArray{T,2}) where T <: Colorant
   binarize(Polysegment(), Gray.(img))

--- a/src/unimodal.jl
+++ b/src/unimodal.jl
@@ -1,15 +1,10 @@
 """
-```
-binarize(UnimodalRosin(), img)
-```
-Uses Rosin's Unimodal threshold algorithm to binarize the image.
+    UnimodalRosin()
 
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
+Constructs a `UnimodalRosin` image binarization algorithm.
 
 # Details
+
 This algorithm first selects the bin in the image histogram with the highest
 frequency. The algorithm then searches from the location of the maximum bin to
 the last bin of the histogram for the first bin with a frequency of 0 (known as
@@ -17,8 +12,8 @@ the minimum bin.). A line is then drawn that passes through both the maximum and
 minimum bins. The bin with the greatest orthogonal distance to the line is
 chosen as the threshold value.
 
-
 ## Assumptions
+
 This algorithm assumes that:
 
 * The histogram is unimodal.
@@ -28,36 +23,26 @@ If the histogram includes multiple bins with a frequency of 0, the algorithm
 will select the first zero bin as its minimum. If there are multiple bins with
 the greatest orthogonal distance, the leftmost bin is selected as the threshold.
 
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-
-# Example
-
-Compute the threshold for the "moonsurface" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("moonsurface")
-img_binary = binarize(UnimodalRosin(), img)
-```
-
 # Reference
+
 1. P. L. Rosin, “Unimodal thresholding,” Pattern Recognition, vol. 34, no. 11, pp. 2083–2096, Nov. 2001.[doi:10.1016/s0031-3203(00)00136-9](https://doi.org/10.1016/s0031-3203%2800%2900136-9)
 """
+struct UnimodalRosin <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::UnimodalRosin,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using Rosin's Unimodal threshold algorithm.
+
+Check [`UnimodalRosin`](@ref ImageBinarization.UnimodalRosin) for more details
+"""
 function binarize(algorithm::UnimodalRosin,  img::AbstractArray{T,2}) where T <: Colorant
-    img₀₁ = zeros(Gray{Bool}, axes(img))
-    edges, counts = build_histogram(img,  256)
-    t = find_threshold(HistogramThresholding.UnimodalRosin(), counts[1:end], edges)
-    for i in CartesianIndices(img)
-      img₀₁[i] = img[i] < t ? 0 : 1
-    end
-    img₀₁
+  img₀₁ = zeros(Gray{Bool}, axes(img))
+  edges, counts = build_histogram(img,  256)
+  t = find_threshold(HistogramThresholding.UnimodalRosin(), counts[1:end], edges)
+  for i in CartesianIndices(img)
+    img₀₁[i] = img[i] < t ? 0 : 1
+  end
+  img₀₁
 end

--- a/src/yen.jl
+++ b/src/yen.jl
@@ -1,15 +1,7 @@
 @doc raw"""
-```
-binarize(Yen(), img)
-```
+    Yen()
 
-Computes the binarization threshold value using Yen's maximum correlation criterion for
-bilevel thresholding.
-
-# Output
-
-Returns the binarized image as an `Array{Gray{Bool},2}`.
-
+Constructs an instance of `Yen` image binarization algorithm.
 
 # Details
 
@@ -44,36 +36,29 @@ Combining these two entropic correlation functions we have
 Finding the discrete value ``s`` which maximises the function ``\psi(s)`` produces
 the sought-after threshold value (i.e. the bin which determines the threshold).
 
-# Arguments
-
-The function argument is described in more detail below.
-
-##  `img`
-
-An `AbstractArray` representing an image. The image is automatically converted
-to `Gray` in order to construct the requisite graylevel histogram.
-
-# Example
-
-Binarize the "cameraman" image in the `TestImages` package.
-
-```julia
-using TestImages, ImageBinarization
-
-img = testimage("cameraman")
-img_binary = binarize(Yen(), img)
-```
-
 # Reference
 
 1. Yen JC, Chang FJ, Chang S (1995), “A New Criterion for Automatic Multilevel Thresholding”, IEEE Trans. on Image Processing 4 (3): 370-378, [doi:10.1109/83.366472](https://doi.org/10.1109/83.366472)
+
+See also: [`binarize`](@ref ImageBinarization.binarize), [`BinarizationAlgorithm`](@ref ImageBinarization.BinarizationAlgorithm)
+"""
+struct Yen <: BinarizationAlgorithm end
+
+
+"""
+    binarize(algorithm::Yen,  img::AbstractArray{T,2}) where T <: Colorant
+
+Binarizes the image using `Yen`'s maximum correlation criterion for
+bilevel thresholding.
+
+Check [`Yen`](@ref ImageBinarization.Yen) for more details.
 """
 function binarize(algorithm::Yen,  img::AbstractArray{T,2}) where T <: Colorant
-    img₀₁ = zeros(Gray{Bool}, axes(img))
-    edges, counts = build_histogram(img,  256)
-    t = find_threshold(HistogramThresholding.Yen(), counts[1:end], edges)
-    for i in CartesianIndices(img)
-      img₀₁[i] = img[i] < t ? 0 : 1
-    end
-    img₀₁
+  img₀₁ = zeros(Gray{Bool}, axes(img))
+  edges, counts = build_histogram(img,  256)
+  t = find_threshold(HistogramThresholding.Yen(), counts[1:end], edges)
+  for i in CartesianIndices(img)
+    img₀₁[i] = img[i] < t ? 0 : 1
+  end
+  img₀₁
 end


### PR DESCRIPTION
The idea of this PR is explained in: https://github.com/JuliaImages/Images.jl/issues/790#issuecomment-478285863

Currently, when `?binarize`, there will be too much docstring to read in REPL, the idea is to make `?binarize` more concise and clearer by:

* move implementation details into concrete `BinarizationAlgorithm`
* hold a list of implemented algorithms in docstring of `BinarizationAlgorithm` -- export it so that `?BinarizationAlgorithm` works -- an alternative to this is to add docstring to the module
* move redundant docstring to the most generic function, the one in `ImageBinarization.jl`

Now `?binarize(Ostu(), img)` only prints
```text
  binarize(algorithm::Otsu,  img::AbstractArray{T,2}) where T <: Colorant

  Binarizes the image using Otsu histogram thresholding method.

  Under the assumption that the image histogram is bimodal the binarization threshold is set so that the
  resultant between-class variance is maximal.

  Check Otsu for more details
```

Note:
* no change in code implementation, only docstring is changed
* the code indentation is changed to 2 spaces. -- the current indentation is a mixture of 4 and 2 spaces

Todo:
* add more guide to `overview` section (In this PR)
* more descriptive docstring to `binarize` and `BinarizationAlgorithm` -- the current one is simply a trivial `Constructs an instance of Otsu image binarization algorithm.` and `Binarizes the image using Otsu histogram thresholding method.` (In future PRs)