### PR TITLE
replace `recommend_size` with function AdaptiveThreshold (closes #41)

### DIFF
--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -13,10 +13,3 @@ function recommend_size(img)
     depwarn("recommend_size is deprecated, use AdaptiveThreshold(img) to directly generate the algorithm", :recommend_size)
     return round(Int, mean(size(img))/8)
 end
-
-# move window_size out of Niblack
-# Deprecated in ImageBinarization v0.3
-function Niblack(window_size, bias)
-    depwarn("deprecated: window_size is no longer used as an `Niblac` field, instead, it's a keyword argument of `binarize`. Please check `Niblack` for more details.", :Niblack)
-    Niblack(bias)
-end

--- a/src/deprecations.jl
+++ b/src/deprecations.jl
@@ -7,16 +7,11 @@ function binarize(f::AbstractImageBinarizationAlgorithm, img::AbstractArray, arg
     binarize(img, f, args...; kwargs...)
 end
 
-# move window_size out of AdaptiveThreshold and unexport recommend_size
+# unexport recommend_size
 # Deprecated in ImageBinarization v0.3
-function AdaptiveThreshold(window_size, percentage)
-    depwarn("deprecated: window_size is no longer used as an `AdaptiveThreshold` field, instead, it's a keyword argument of `binarize`. Please check `AdaptiveThreshold` for more details.", :AdaptiveThreshold)
-    AdaptiveThreshold(percentage)
-end
-
 function recommend_size(img)
-    depwarn("deprecated: `binarize` automatically calls `recommend_size` now, it will be unexported in the future. Please check `AdaptiveThreshold` for more details.", :recommend_size)
-    default_AdaptiveThreshold_window_size(img)
+    depwarn("recommend_size is deprecated, use AdaptiveThreshold(img) to directly generate the algorithm", :recommend_size)
+    return round(Int, mean(size(img))/8)
 end
 
 # move window_size out of Niblack

--- a/test/adaptive_threshold.jl
+++ b/test/adaptive_threshold.jl
@@ -1,4 +1,3 @@
-using ImageBinarization: default_AdaptiveThreshold_window_size
 @testset "adaptive_threshold" begin
     @info "Test: AdaptiveThreshold"
 
@@ -7,24 +6,21 @@ using ImageBinarization: default_AdaptiveThreshold_window_size
         img = copy(img_gray)
 
         # AdaptiveThreshold
-        @test AdaptiveThreshold() == AdaptiveThreshold(15)
-        @test AdaptiveThreshold(15) == AdaptiveThreshold(percentage=15)
+        @test AdaptiveThreshold(window_size=32) == AdaptiveThreshold(32, 15)
+        @test AdaptiveThreshold(img_gray) == AdaptiveThreshold(window_size=8)
 
         # window_size non-positive integer
-        f = AdaptiveThreshold()
-        @test_throws ArgumentError binarize(img, f, window_size = -10)
-        @test_throws TypeError binarize(img, f, window_size = 32.5)
+        @test_throws ArgumentError AdaptiveThreshold(window_size=-10)
+        @test_throws TypeError AdaptiveThreshold(window_size=32.5)
         # percentage ∈ [0, 100]
-        @test_throws ArgumentError AdaptiveThreshold(-10)
-        @test_throws ArgumentError AdaptiveThreshold(150)
+        @test_throws ArgumentError AdaptiveThreshold(window_size=32, percentage=-10)
+        @test_throws ArgumentError AdaptiveThreshold(window_size=32, percentage=150)
 
         # binarize
-        f = AdaptiveThreshold(percentage=15)
+        f = AdaptiveThreshold(img, percentage=15)
         binarized_img_1 = binarize(img, f)
         @test img == img_gray # img unchanged
         @test eltype(binarized_img_1) == Gray{N0f8}
-        @test binarize(img, f,
-                       window_size=default_AdaptiveThreshold_window_size(img)) == binarized_img_1
 
         binarized_img_2 = binarize(Gray{Bool}, img, f)
         @test img == img_gray # img unchanged
@@ -47,7 +43,7 @@ using ImageBinarization: default_AdaptiveThreshold_window_size
     @testset "Types" begin
         # Gray
         img_gray = imresize(float64.(testimage("lena_gray_256")); ratio=0.25)
-        f = AdaptiveThreshold(percentage=15)
+        f = AdaptiveThreshold(img_gray, percentage=15)
 
         type_list = generate_test_types([Float32, N0f8], [Gray])
         for T in type_list
@@ -57,7 +53,7 @@ using ImageBinarization: default_AdaptiveThreshold_window_size
 
         # Color3
         img_color = imresize(float64.(testimage("lena_color_256")); ratio=0.25)
-        f = AdaptiveThreshold(percentage=15)
+        f = AdaptiveThreshold(img_color, percentage=15)
 
         type_list = generate_test_types([Float32, N0f8], [RGB, Lab])
         for T in type_list
@@ -69,7 +65,7 @@ using ImageBinarization: default_AdaptiveThreshold_window_size
     @testset "Numerical" begin
         # Check that the image only has ones or zeros.
         img = imresize(float64.(testimage("lena_gray_256")); ratio=0.25)
-        f = AdaptiveThreshold(percentage=15)
+        f = AdaptiveThreshold(img, percentage=15)
         img₀₁ = binarize(img, f)
         non_zeros = findall(x -> x != 0.0 && x != 1.0, img₀₁)
         @test length(non_zeros) == 0
@@ -83,12 +79,11 @@ using ImageBinarization: default_AdaptiveThreshold_window_size
 
     @testset "Miscellaneous" begin
         img = testimage("lena_gray_256")
-        @test default_AdaptiveThreshold_window_size(img) == 32
 
         # deprecations
-        @test (@test_deprecated AdaptiveThreshold(32, 15)) == AdaptiveThreshold(15)
-        @test (@test_deprecated AdaptiveThreshold(window_size=32, percentage=15)) == AdaptiveThreshold(percentage=15)
-        @test (@test_deprecated recommend_size(img)) == ImageBinarization.default_AdaptiveThreshold_window_size(img)
+        @test (@test_deprecated AdaptiveThreshold()) == AdaptiveThreshold(32, 15.0)
+        @test (@test_deprecated AdaptiveThreshold(percentage = 15)) == AdaptiveThreshold(32, 15)
+        @test (@test_deprecated recommend_size(img)) == 32
     end
 
 end

--- a/test/niblack.jl
+++ b/test/niblack.jl
@@ -1,5 +1,3 @@
-using ImageBinarization: default_Niblack_window_size
-
 @testset "niblack" begin
     @info "Test: Niblack"
 
@@ -8,21 +6,18 @@ using ImageBinarization: default_Niblack_window_size
         img = copy(img_gray)
 
         # Niblack
-        @test Niblack() == Niblack(0.2)
-        @test Niblack(0.2) == Niblack(bias=0.2)
+        @test Niblack() == Niblack(7, 0.2)
+        @test Niblack(7, 0.2) == Niblack(window_size=7, bias=0.2)
 
         # window_size non-positive integer
-        f = Niblack()
-        @test_throws ArgumentError binarize(img, f, window_size = -10)
-        @test_throws TypeError binarize(img, f, window_size = 32.5)
+        @test_throws ArgumentError Niblack(window_size = -10)
+        @test_throws TypeError Niblack(window_size = 32.5)
 
         # binarize
-        f = Niblack(bias=0.2)
+        f = Niblack(window_size = 7, bias=0.2)
         binarized_img_1 = binarize(img, f)
         @test img == img_gray # img unchanged
         @test eltype(binarized_img_1) == Gray{N0f8}
-        @test binarize(img, f,
-                       window_size=default_Niblack_window_size(img)) == binarized_img_1
 
         binarized_img_2 = binarize(Gray{Bool}, img, f)
         @test img == img_gray # img unchanged
@@ -45,7 +40,7 @@ using ImageBinarization: default_Niblack_window_size
     @testset "Types" begin
         # Gray
         img_gray = imresize(testimage("lena_gray_256"); ratio=0.25)
-        f = Niblack(bias=0.2)
+        f = Niblack(window_size = 7, bias=0.2)
 
         type_list = generate_test_types([Float32, N0f8], [Gray])
         for T in type_list
@@ -55,7 +50,7 @@ using ImageBinarization: default_Niblack_window_size
 
         # Color3
         img_color = imresize(testimage("lena_color_256"); ratio=0.25)
-        f = Niblack(bias=0.2)
+        f = Niblack(window_size = 7, bias=0.2)
 
         type_list = generate_test_types([Float32, N0f8], [RGB, Lab])
         for T in type_list
@@ -67,7 +62,7 @@ using ImageBinarization: default_Niblack_window_size
     @testset "Numerical" begin
         # Check that the image only has ones or zeros.
         img = imresize(testimage("lena_gray_256"); ratio=0.25)
-        f = Niblack(bias=0.2)
+        f = Niblack(window_size = 7, bias=0.2)
         img₀₁ = binarize(img, f)
         non_zeros = findall(x -> x != 0.0 && x != 1.0, img₀₁)
         @test length(non_zeros) == 0
@@ -89,20 +84,11 @@ using ImageBinarization: default_Niblack_window_size
                 target_row₀ = (target_row + i) % 50
                 target_col₀ = (target_col + j) % 50
 
-                img_bin = binarize(img₀, Niblack(bias = -6), window_size=25)
+                img_bin = binarize(img₀, Niblack(window_size = 25, bias = -6))
                 @test sum(img_bin .== 0) == 1
                 @test img_bin[target_row₀, target_col₀] == 0
             end
         end
-    end
-
-    @testset "Miscellaneous" begin
-        img = testimage("lena_gray_256")
-        @test default_Niblack_window_size(img) == 7
-
-        # deprecations
-        @test (@test_deprecated Niblack(7, 0.2)) == Niblack(0.2)
-        @test (@test_deprecated Niblack(window_size=7, bias=0.2)) == Niblack(bias=0.2)
     end
 
 end


### PR DESCRIPTION
This PR reverts some deprecation on `window_size` introduced by #30 and #42, and then adopt the idea introduced by #41, i.e.,

```julia
f = AdaptiveThreshold(img)
binarized_img = binarize(img, f)
```

P.S., the old equivalent usage (in master branch) is:

```julia
f = AdaptiveThreshold(window_size=recommend_size(img))
binarized_img = binarize(img, f)
```