### PR TITLE
ImageBinarization v0.2.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageBinarization"
 uuid = "cbc4b850-ae4b-5111-9e64-df94c024a13d"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.1.1"
+version = "0.2.0"
 
 [deps]
 ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"


### PR DESCRIPTION
I feel like we can tag a version 0.2.0 first to stabilize the API, and then focus on potential performance optimization.