### PR TITLE
bump compat for ColorTypes "0.10" and ReferenceTests "0.9"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
+Compat = "2"
 ColorTypes = "0.7, 0.8, 0.9"
 ColorVectorSpace = "0.6, 0.7, 0.8"
 HistogramThresholding = "0.1, 0.2"
@@ -26,6 +27,7 @@ ReferenceTests = "0.7, 0.8"
 julia = "1"
 
 [extras]
+Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"

--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ ImageContrastAdjustment = "0.1, 0.2, 0.3"
 ImageCore = "0.8.3"
 MappedArrays = "0.2"
 Polynomials = "0.5, 0.6"
-ReferenceTests = "0.7, 0.8"
+ReferenceTests = "0.7, 0.8, 0.9"
 julia = "1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 Compat = "2"
-ColorTypes = "0.7, 0.8, 0.9"
+ColorTypes = "0.7, 0.8, 0.9, 0.10"
 ColorVectorSpace = "0.6, 0.7, 0.8"
 HistogramThresholding = "0.1, 0.2"
 ImageContrastAdjustment = "0.1, 0.2, 0.3"


### PR DESCRIPTION
closes #58 

The first commit explicitly specifies the version of Compat to get a successful version resolve.