### PR TITLE
deprecate matrix in favor of jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,15 @@ julia:
   - 1.0
   - 1
   - nightly
-matrix:
-  allow_failures:
-    - julia: nightly
-  fast_finish: true
 notifications:
   email: false
 after_success:
   - julia -e 'using Pkg; Pkg.add("Coverage"); using Coverage; Codecov.submit(process_folder())'
 
 jobs:
+  allow_failures:
+    - julia: nightly
+  fast_finish: true
   include:
     - stage: "Documentation"
       julia: 1.0


### PR DESCRIPTION
The last commit to gh-pages branch is five months ago.

Using both seems problematic and makes travis ignore the docs stage.