### PR TITLE
upgrade to ImageCore v0.9, ColorVectorSpace v0.9, and Polynomials v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
 version = "0.2.4"
 
 [deps]
-ColorTypes = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 HistogramThresholding = "2c695a8d-9458-5d45-9878-1b8a99cf7853"
 ImageContrastAdjustment = "f332f351-ec65-5f6a-b3d1-319c6670881a"
@@ -15,14 +14,12 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ColorTypes = "0.7, 0.8, 0.9, 0.10"
-ColorVectorSpace = "0.6, 0.7, 0.8"
+ColorVectorSpace = "0.6, 0.7, 0.8, 0.9"
 HistogramThresholding = "0.1, 0.2"
 ImageContrastAdjustment = "0.1, 0.2, 0.3"
-ImageCore = "0.8.3"
-Polynomials = "1.0"
+ImageCore = "0.8.3, 0.9"
+Polynomials = "1, 2"
 Reexport = "0.2, 1.0"
-ReferenceTests = "0.7, 0.8"
 julia = "1"
 
 [extras]

--- a/src/BinarizationAPI/BinarizationAPI.jl
+++ b/src/BinarizationAPI/BinarizationAPI.jl
@@ -2,7 +2,7 @@
 # proposed in https://github.com/JuliaImages/ImagesAPI.jl/pull/3
 module BinarizationAPI
 
-using ColorTypes
+using ImageCore # we actually only need ColorTypes
 const GenericGrayImage = AbstractArray{<:Union{Number, AbstractGray}}
 
 """

--- a/src/algorithms/adaptive_threshold.jl
+++ b/src/algorithms/adaptive_threshold.jl
@@ -131,4 +131,4 @@ end
 
 # first do Color3 to Gray conversion
 (f::AdaptiveThreshold)(out::GenericGrayImage, img::AbstractArray{<:Color3}, args...; kwargs...) =
-    f(out, of_eltype(Gray, img), args...; kwargs...)
+    f(out, eltype(out).(img), args...; kwargs...)

--- a/src/algorithms/niblack.jl
+++ b/src/algorithms/niblack.jl
@@ -107,4 +107,4 @@ function (f::Niblack)(out::GenericGrayImage,
 end
 
 (f::Niblack)(out::GenericGrayImage, img::AbstractArray{<:Color3}) =
-    f(out, of_eltype(Gray, img))
+    f(out, eltype(out).(img))

--- a/src/algorithms/polysegment.jl
+++ b/src/algorithms/polysegment.jl
@@ -65,4 +65,4 @@ function (f::Polysegment)(out::GenericGrayImage, img::GenericGrayImage)
 end
 
 (f::Polysegment)(out::GenericGrayImage, img::AbstractArray{<:Color3}) =
-    f(out, of_eltype(Gray, img))
+    f(out, eltype(out).(img))

--- a/src/algorithms/sauvola.jl
+++ b/src/algorithms/sauvola.jl
@@ -122,4 +122,4 @@ function (f::Sauvola)(out::GenericGrayImage, img::GenericGrayImage)
 end
 
 (f::Sauvola)(out::GenericGrayImage, img::AbstractArray{<:Color3}) =
-    f(out, of_eltype(Gray, img))
+    f(out, eltype(out).(img))

--- a/src/algorithms/single_histogram_threshold.jl
+++ b/src/algorithms/single_histogram_threshold.jl
@@ -104,4 +104,4 @@ function (f::SingleHistogramThreshold)(out::GenericGrayImage, img::GenericGrayIm
 end
 
 (f::SingleHistogramThreshold)(out::GenericGrayImage, img::AbstractArray{<:Color3}) =
-    f(out, of_eltype(Gray, img))
+    f(out, eltype(out).(img))


### PR DESCRIPTION
MappedArrays v0.4 shipped by ImageCore v0.8.22(the last v0.8.x version) actually breaks this package because `of_eltype(Gray, img)` is not inferrable as concrete type (see https://github.com/JuliaArrays/MappedArrays.jl/pull/43):

```julia
julia> img = Lab{Float32}.(rand(RGB, 4, 4));

julia> of_eltype(Gray, img) |> eltype
Any # oops; previously it is `Gray{Float32}`
```

Until someone(e.g., me) really make the effort to improve MappedArrays, we can't use `of_eltype` to reduce the extra conversion.

I also removed `ColorTypes` as a direct dependency to reduce the version management complexity.

---

I've tested it locally that it works for ImageCore v0.8.22.

closes #77 
closes #78