### PR TITLE
remove outdated reference entries

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,9 +1,10 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+ImageBinarization = "cbc4b850-ae4b-5111-9e64-df94c024a13d"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageShow = "4e3cecfd-b093-5904-9786-8bbb286a6a31"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
 
 [compat]
-Documenter = "~0.23"
+Documenter = "0.27"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,4 +1,3 @@
-push!(LOAD_PATH,"../src/")
 using Documenter, ImageBinarization
 makedocs(sitename="Documentation",
     format = Documenter.HTML(

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -23,44 +23,9 @@ ImageBinarization.BinarizationAPI.AbstractImageBinarizationAlgorithm
 AdaptiveThreshold
 ```
 
-### Balanced
-```@docs
-Balanced
-```
-
-### Entropy
-```@docs
-Entropy
-```
-
-### Intermodes
-```@docs
-Intermodes
-```
-
-### Minimum Error
-```@docs
-MinimumError
-```
-
-### Minimum Intermodes
-```@docs
-MinimumIntermodes
-```
-
-### Moments
-```@docs
-Moments
-```
-
 ### Niblack
 ```@docs
 Niblack
-```
-
-### Otsu
-```@docs
-Otsu
 ```
 
 ### Polysegment
@@ -73,12 +38,11 @@ Polysegment
 Sauvola
 ```
 
-### Unimodal Rosin
-```@docs
-UnimodalRosin
-```
+### Algorithms that utilizes single histogram-threshold
 
-### Yen
+The core functionality of these algorithms are supported by
+[HistogramThresholding.jl](https://github.com/JuliaImages/HistogramThresholding.jl)
+
 ```@docs
-Yen
+SingleHistogramThreshold
 ```

--- a/src/algorithms/single_histogram_threshold.jl
+++ b/src/algorithms/single_histogram_threshold.jl
@@ -39,7 +39,7 @@ construct the requisite graylevel histogram.
 `ThresholdAlgorithm` is an Abstract type defined in `ThresholdAlgorithm.jl`, it provides various
 threshold finding algorithms:
 
-$(mapreduce(x->"- [`"*string(x)*"`](@ref)", (x,y)->x*"\n"*y, threshold_methods))
+$(mapreduce(x->"- `"*string(x)*"`", (x,y)->x*"\n"*y, threshold_methods))
 
 For the more detailed explaination and the construction, please refer to each concrete algorithm.
 For example, type `?Otsu` in REPL will give you more details on how to use `Otsu` methods.


### PR DESCRIPTION
fixes #85 

Also upgrade to Documenter v0.27

This raises another issue https://github.com/JuliaImages/HistogramThresholding.jl/issues/34 that we still don't have docstrings for those types https://github.com/JuliaImages/HistogramThresholding.jl/blob/0e849d1fd81ff30c436d91eca06f6b031421c40f/src/HistogramThresholding.jl#L6-L15

@zygmuntszpak Do you think we want to merge this until we refactor HistogramThresholding API?