### PR TITLE
Reconciles changes in HistogramThresholding.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,11 @@
 name = "ImageBinarization"
 uuid = "cbc4b850-ae4b-5111-9e64-df94c024a13d"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.2.7"
+version = "0.2.8"
 
 [deps]
 ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 HistogramThresholding = "2c695a8d-9458-5d45-9878-1b8a99cf7853"
-ImageContrastAdjustment = "f332f351-ec65-5f6a-b3d1-319c6670881a"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Polynomials = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
@@ -15,8 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 ColorVectorSpace = "0.6, 0.7, 0.8, 0.9"
-HistogramThresholding = "0.1, 0.2"
-ImageContrastAdjustment = "0.1, 0.2, 0.3"
+HistogramThresholding = "0.3"
 ImageCore = "0.8.3, 0.9"
 Polynomials = "1, 2"
 Reexport = "0.2, 1.0"
@@ -25,10 +23,10 @@ julia = "1"
 [extras]
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"
 ImageTransformations = "02fcd773-0e25-5acc-982a-7f6622650795"
+OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 ReferenceTests = "324d217c-45ce-50fc-942e-d289b448e8cf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestImages = "5e47fb64-e119-507b-a336-dd2b206d9990"
-OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 
 [targets]
 test = ["ImageMagick", "ImageTransformations", "OffsetArrays", "ReferenceTests", "Test", "TestImages"]

--- a/docs/src/reference.md
+++ b/docs/src/reference.md
@@ -38,11 +38,56 @@ Polysegment
 Sauvola
 ```
 
-### Algorithms that utilizes single histogram-threshold
+## Algorithms that utilizes single histogram-threshold
 
 The core functionality of these algorithms are supported by
 [HistogramThresholding.jl](https://github.com/JuliaImages/HistogramThresholding.jl)
 
 ```@docs
 SingleHistogramThreshold
+```
+
+### Otsu
+```@docs
+HistogramThresholding.Otsu
+```
+
+### MinimumIntermodes
+```@docs
+HistogramThresholding.MinimumIntermodes
+```
+
+### Intermodes
+```@docs
+HistogramThresholding.Intermodes
+```
+
+### MinimumError
+```@docs
+HistogramThresholding.MinimumError
+```
+
+### Moments
+```@docs
+HistogramThresholding.Moments
+```
+
+### UnimodalRosin
+```@docs
+HistogramThresholding.UnimodalRosin
+```
+
+### Entropy
+```@docs
+HistogramThresholding.Entropy
+```
+
+### Balanced
+```@docs
+HistogramThresholding.Balanced
+```
+
+### Yen
+```@docs
+HistogramThresholding.Yen
 ```

--- a/src/ImageBinarization.jl
+++ b/src/ImageBinarization.jl
@@ -6,7 +6,6 @@ using Polynomials
 using Statistics
 using Reexport
 
-using ImageContrastAdjustment
 @reexport using HistogramThresholding
 
 using ImageCore
@@ -18,7 +17,7 @@ using ColorVectorSpace
 include("BinarizationAPI/BinarizationAPI.jl")
 import .BinarizationAPI: AbstractImageBinarizationAlgorithm,
                          binarize, binarize!
-import HistogramThresholding: ThresholdAlgorithm
+import HistogramThresholding: AbstractThresholdAlgorithm
 
 include("integral_image.jl")
 include("util.jl")

--- a/src/algorithms/adaptive_threshold.jl
+++ b/src/algorithms/adaptive_threshold.jl
@@ -13,6 +13,8 @@ illumination.
 Return the binarized image as an `Array{Gray{T}}` of size `size(img)`. If
 `T` is not specified, it is inferred from `out` and `img`.
 
+# Extended help
+
 # Details
 
 If the value of a pixel is `t` percent less than the average of an ``s

--- a/src/algorithms/niblack.jl
+++ b/src/algorithms/niblack.jl
@@ -13,6 +13,8 @@ image is textual.
 Return the binarized image as an `Array{Gray{T}}` of size `size(img)`. If
 `T` is not specified, it is inferred from `out` and `img`.
 
+# Extended help
+
 # Details
 
 The input image is binarized by varying the threshold across the image, using

--- a/src/algorithms/polysegment.jl
+++ b/src/algorithms/polysegment.jl
@@ -13,6 +13,8 @@ into two categories (foreground and background).
 Return the binarized image as an `Array{Gray{T}}` of size `size(img)`. If
 `T` is not specified, it is inferred from `out` and `img`.
 
+# Extended help
+
 # Details
 
 The approach involves constructing a univariate second-degree polynomial

--- a/src/algorithms/sauvola.jl
+++ b/src/algorithms/sauvola.jl
@@ -13,6 +13,8 @@ assumption that the input image is textual.
 Return the binarized image as an `Array{Gray{T}}` of size `size(img)`. If
 `T` is not specified, it is inferred from `out` and `img`.
 
+# Extended help
+
 # Details
 
 The input image is binarized by varying the threshold across the image, using

--- a/src/algorithms/single_histogram_threshold.jl
+++ b/src/algorithms/single_histogram_threshold.jl
@@ -13,10 +13,10 @@ threshold_methods = (
 
 """
     SingleHistogramThreshold <: AbstractImageBinarizationAlgorithm
-    SingleHistogramThreshold(alg::ThresholdAlgorithm; nbins=256)
+    SingleHistogramThreshold(alg::AbstractThresholdAlgorithm; nbins=256)
 
-    binarize([T,] img, f::ThresholdAlgorithm; nbins=256)
-    binarize!([out,] img, f::ThresholdAlgorithm; nbins=256)
+    binarize([T,] img, f::AbstractThresholdAlgorithm; nbins=256)
+    binarize!([out,] img, f::AbstractThresholdAlgorithm; nbins=256)
 
 Binarizes the image `img` using the threshold found by given threshold finding algorithm `alg`.
 
@@ -34,10 +34,10 @@ The function argument is described in more detail below.
 The image that needs to be binarized.  The image is automatically converted to `Gray` in order to
 construct the requisite graylevel histogram.
 
-## `alg::ThresholdAlgorithm`
+## `alg::AbstractThresholdAlgorithm`
 
-`ThresholdAlgorithm` is an Abstract type defined in `ThresholdAlgorithm.jl`, it provides various
-threshold finding algorithms:
+`AbstractThresholdAlgorithm` is an abstract type defined in `ThresholdAPI.jl` in the
+`HistogramThreshold.jl` package, it provides various threshold finding algorithms:
 
 $(mapreduce(x->"- `"*string(x)*"`", (x,y)->x*"\n"*y, threshold_methods))
 
@@ -74,24 +74,24 @@ img_binary = binarize(img, f)
 struct SingleHistogramThreshold{T} <: AbstractImageBinarizationAlgorithm
     alg::T
     nbins::Int
-    function SingleHistogramThreshold(alg::T; nbins::Integer) where T <: ThresholdAlgorithm
+    function SingleHistogramThreshold(alg::T; nbins::Integer) where T <: AbstractThresholdAlgorithm
         new{T}(alg, nbins)
     end
 end
 
-function binarize!(out::GenericGrayImage, img, f::ThresholdAlgorithm, args...; nbins::Integer=256, kwargs...)
+function binarize!(out::GenericGrayImage, img, f::AbstractThresholdAlgorithm, args...; nbins::Integer=256, kwargs...)
     binarize!(out, img, SingleHistogramThreshold(f, nbins=nbins), args...; kwargs...)
 end
-function binarize!(img::GenericGrayImage, f::ThresholdAlgorithm, args...; nbins::Integer=256, kwargs...)
+function binarize!(img::GenericGrayImage, f::AbstractThresholdAlgorithm, args...; nbins::Integer=256, kwargs...)
     binarize!(img, SingleHistogramThreshold(f, nbins=nbins), args...; kwargs...)
 end
-function binarize(::Type{T}, img, f::ThresholdAlgorithm, args...; nbins::Integer=256, kwargs...) where T
+function binarize(::Type{T}, img, f::AbstractThresholdAlgorithm, args...; nbins::Integer=256, kwargs...) where T
     binarize(T, img, SingleHistogramThreshold(f, nbins=nbins), args...; kwargs...)
 end
-function binarize(img, f::ThresholdAlgorithm, args...; nbins::Integer=256, kwargs...)
+function binarize(img, f::AbstractThresholdAlgorithm, args...; nbins::Integer=256, kwargs...)
     binarize(ccolor(Gray, eltype(img)), img, SingleHistogramThreshold(f, nbins=nbins), args...; kwargs...)
 end
-function binarize(img::AbstractArray{T}, f::ThresholdAlgorithm, args...; kwargs...) where T <: Number
+function binarize(img::AbstractArray{T}, f::AbstractThresholdAlgorithm, args...; kwargs...) where T <: Number
     # issue #46: Do not promote Number to Gray{<:Number}
     binarize(T, img, f, args...; kwargs...)
 end


### PR DESCRIPTION
* Adds docstrings for algorithms provided by `HistogramThresholding.jl`
* Removes `ImageContrastAdjustment.jl` dependency since `build_histogram` is now provided by `HistogramThresholding.jl`
* Sets minimum `HistogramThresholding.jl` compat version to 0.3