### PR TITLE
[compat] ImageCore 0.10

### DIFF
--- a/.github/workflows/UnitTest.yml
+++ b/.github/workflows/UnitTest.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.0', '1.6', '1', 'nightly']
+        julia-version: ['1.6', '1', 'nightly']
         os: [ubuntu-latest]
         arch: [x64]
         include:

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageBinarization"
 uuid = "cbc4b850-ae4b-5111-9e64-df94c024a13d"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.2.10"
+version = "0.3.0"
 
 [deps]
 HistogramThresholding = "2c695a8d-9458-5d45-9878-1b8a99cf7853"
@@ -16,7 +16,7 @@ HistogramThresholding = "0.3"
 ImageCore = "0.9, 0.10"
 Polynomials = "1, 2, 3"
 Reexport = "0.2, 1.0"
-julia = "1"
+julia = "1.6"
 
 [extras]
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"

--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,9 @@
 name = "ImageBinarization"
 uuid = "cbc4b850-ae4b-5111-9e64-df94c024a13d"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
-ColorVectorSpace = "c3611d14-8923-5661-9e6a-0046d554d3a4"
 HistogramThresholding = "2c695a8d-9458-5d45-9878-1b8a99cf7853"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -13,9 +12,8 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-ColorVectorSpace = "0.6, 0.7, 0.8, 0.9"
 HistogramThresholding = "0.3"
-ImageCore = "0.8.3, 0.9"
+ImageCore = "0.9, 0.10"
 Polynomials = "1, 2, 3"
 Reexport = "0.2, 1.0"
 julia = "1"

--- a/src/ImageBinarization.jl
+++ b/src/ImageBinarization.jl
@@ -11,7 +11,6 @@ using Reexport
 using ImageCore
 using ImageCore.MappedArrays
 using ImageCore: GenericGrayImage
-using ColorVectorSpace
 
 # TODO: port BinarizationAPI to ImagesAPI
 include("BinarizationAPI/BinarizationAPI.jl")
@@ -43,7 +42,7 @@ export
     Niblack,
     Polysegment,
     Sauvola,
-    
+
     # also reexport algorithms in HistogramThresholding
     SingleHistogramThreshold
 


### PR DESCRIPTION
This also removes the explicit dependence on ColorVectorSpace
in favor of implicit via ImageCore.