### PR TITLE
Update compat to polynomial 4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 HistogramThresholding = "0.3"
 ImageCore = "0.9, 0.10"
-Polynomials = "1, 2, 3"
+Polynomials = "1, 2, 3, 4"
 Reexport = "0.2, 1.0"
 julia = "1.6"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ImageBinarization"
 uuid = "cbc4b850-ae4b-5111-9e64-df94c024a13d"
 authors = ["Dr. Zygmunt L. Szpak <zygmunt.szpak@gmail.com>"]
-version = "0.3.0"
+version = "0.3.1"
 
 [deps]
 HistogramThresholding = "2c695a8d-9458-5d45-9878-1b8a99cf7853"


### PR DESCRIPTION
ImageBinarization pins Polynomials to version 3, which keeps Images.jl from updating to the latest version, which causes a host of other things not to update. 

Switching to version 4 passes local tests. 